### PR TITLE
Only look up the branch by name-rev.

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -12,7 +12,7 @@ ghwd() {
   local relative_path=${full_path#$git_base_path} # remove leading git_base_path from working directory
 
   # Figure out current git branch
-  local git_where=$(command git symbolic-ref -q HEAD || command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
+  local git_where=$(command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
   local branch=${git_where#(refs/heads/|tags/)}
 
   local url="$base_url/tree/$branch$relative_path"


### PR DESCRIPTION
Was getting 404's for /tree/refs/heads/master/subdir/subdir, instead of /tree/branchname/subdir/subdir.

Not sure what case "command git symbolic-ref -q HEAD || " was handling.
