### PR TITLE
use xdg-open when available

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -29,4 +29,7 @@ branch=${git_where#refs\/heads\/}
 url="$base_url/tree/$branch$relative_path"
 
 echo $url
-open $url
+
+open=open
+command -v xdg-open && open=xdg-open
+$open $url


### PR DESCRIPTION
`open` might work on OS X, but doesn't really exist elsewhere ­— this makes it work on your average Linux system and such [=
