### PR TITLE
Wrap error message and exit code so valid commands dont return 1

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -44,4 +44,4 @@ for opener in xdg-open open cygstart "start"; {
   fi
 }
 
-$open $url || echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start" && exit 1;
+$open $url || (echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start" && exit 1);


### PR DESCRIPTION
Currently it seems like the script always exits with a code of `1`.

```sh
> ghwd; ret_code=$?; echo $ret_code
https://github.com/ampersandjs/ampersand-view/tree/master
/usr/bin/open
1
```
