### PR TITLE
use git remote get-url so that insteadOf config is respected

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Figure out github repo base URL
-base_url=$(git config --get remote.origin.url)
+base_url=$(git remote get-url origin)
 base_url=${base_url%\.git} # remove .git from end of string
 
 # Fix git@github.com: URLs


### PR DESCRIPTION
Thanks for ghwd - a real timesaver. 
If you use insteadOf options in your .gitconfig, this means that they will be expanded - in my case from apb:foobar to git@github.com:abridgett/foobar