### PR TITLE
Fix: error which caused ghwd to open a 404 page when in a subdirectory

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -38,12 +38,14 @@ fi
 git_where=$(command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
 
 # Remove cruft from branchname
-branch=${git_where#refs\/heads\/}
+branch="${git_where#refs\/heads\/}"
+branch="${branch#tags\/}"
+branch="${branch%^0}"
 
 [[ $base_url == *bitbucket* ]] && tree="src" || tree="tree"
 url="$base_url/$tree/$branch$relative_path"
 
-echo $url
+echo "$url"
 
 # Check for various OS openers. Quit as soon as we find one that works.
 # Don't assume this will work, provide a helpful diagnostic if it fails.


### PR DESCRIPTION
Fixed an error which cased ghwd to open a 404 page when in a subdirectory.  This was fixed by adding lines 42 and 43, which removed the prefix "tags" and suffix "^0" from the branch variable—these additions did not cause a problem when opening the frontpage of a github repository, but would not allow subdirectories to open, e.g., it would try to open "https://github.com/zeke/ghwd/tree/tags/v1.1.2^0/bin" and fail.