### PR TITLE
Feature/silent and verbose

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -62,7 +62,7 @@ base_url=${base_url//git@gitlab\.com:/https:\/\/gitlab\.com\/}
 # Validate that this folder is a git folder
 git branch 2>/dev/null 1>&2
 if [ $? -ne 0 ]; then
-  echo "Not a git repo!"
+  echo "Not a git repo!" >&2
   exit $?
 fi
 

--- a/bin/ghwd
+++ b/bin/ghwd
@@ -1,22 +1,15 @@
 #!/usr/bin/env bash
 
-declare version="1.1.2"
-
 usage() {
 	printf '%s\n%s\n' \
 		'usage '"`basename "${1:-ghwd}"`"' -- open git URL in browser matching current branch and working directory' \
 		'ghwd [-rsvVh]' 
 	exit 64;
 }
-version() {
-	printf '%s\n' "`basename "${1:-ghwd}"`"' version '"$version"''
-	exit 0;
-}
-
 declare verbosity=1 #defaults to verbose
 declare f_return_only=0
 
-while getopts ":rsvVh" opt "$@"; do
+while getopts ":rsvh" opt "$@"; do
 	case "$opt" in
 		(r)
 			#return mode returns the url, but does not open it
@@ -27,10 +20,7 @@ while getopts ":rsvVh" opt "$@"; do
 			verbosity=0
 			;;
 		(v)
-			verbosity=1
-			;;
-		(V)
-			version
+			let "++verbosity"
 			;;
 		(h)
 			usage

--- a/bin/ghwd
+++ b/bin/ghwd
@@ -3,7 +3,7 @@
 usage() {
 	printf '%s\n%s\n' \
 		'usage '"`basename "${1:-ghwd}"`"' -- open git URL in browser matching current branch and working directory' \
-		'ghwd [-rsvVh]' 
+		'ghwd [-rsvh] [file]' 
 	exit 64;
 }
 declare verbosity=1 #defaults to verbose

--- a/bin/ghwd
+++ b/bin/ghwd
@@ -50,7 +50,7 @@ echo "$url"
 # Check for various OS openers. Quit as soon as we find one that works.
 # Don't assume this will work, provide a helpful diagnostic if it fails.
 for opener in xdg-open open cygstart "start"; {
-  if command -v $opener; then
+  if command -v $opener &>/dev/null; then
     open=$opener;
     break;
   fi

--- a/bin/ghwd
+++ b/bin/ghwd
@@ -1,5 +1,42 @@
 #!/usr/bin/env bash
 
+declare version="1.1.2"
+
+usage() {
+	printf '%s\n%s\n' \
+		'usage '"`basename "${1:-ghwd}"`"' -- open git URL in browser matching current branch and working directory' \
+		'ghwd [-svVh]' 
+	exit 64;
+}
+version() {
+	printf '%s\n' "`basename "${1:-ghwd}"`"' version '"$version"''
+	exit 0;
+}
+
+declare verbosity=1 #defaults to verbose
+
+while getopts ":svVh" opt "$@"; do
+	case "$opt" in
+		(s)
+			verbosity=0
+			;;
+		(v)
+			verbosity=1
+			;;
+		(V)
+			version
+			;;
+		(h)
+			usage
+			;;
+		(\?) 
+			printf 'unknown argument '"$OPTARG"'' >&2
+			exit 1;
+			;;
+	esac
+done
+shift $((OPTIND-1))
+
 # Figure out github repo base URL
 base_url=$(git config --get remote.origin.url)
 base_url=${base_url%\.git} # remove .git from end of string
@@ -19,14 +56,14 @@ base_url=${base_url//git@gitlab\.com:/https:\/\/gitlab\.com\/}
 # Validate that this folder is a git folder
 git branch 2>/dev/null 1>&2
 if [ $? -ne 0 ]; then
-  echo Not a git repo!
+  echo "Not a git repo!"
   exit $?
 fi
 
 # Find current directory relative to .git parent
-full_path=$(pwd)
-git_base_path=$(cd ./$(git rev-parse --show-cdup); pwd)
-relative_path=${full_path#$git_base_path} # remove leading git_base_path from working directory
+full_path="$(pwd)"
+git_base_path="$(cd ./$(git rev-parse --show-cdup); pwd)"
+relative_path="${full_path#$git_base_path}" # remove leading git_base_path from working directory
 
 # If filename argument is present, append it
 if [ "$1" ]; then
@@ -35,7 +72,7 @@ fi
 
 # Figure out current git branch
 # git_where=$(command git symbolic-ref -q HEAD || command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
-git_where=$(command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
+git_where="$(command git name-rev --name-only --no-undefined --always HEAD)" 2>/dev/null
 
 # Remove cruft from branchname
 branch="${git_where#refs\/heads\/}"
@@ -45,7 +82,7 @@ branch="${branch%^0}"
 [[ $base_url == *bitbucket* ]] && tree="src" || tree="tree"
 url="$base_url/$tree/$branch$relative_path"
 
-echo "$url"
+test $verbosity -ge 1 && echo "$url"
 
 # Check for various OS openers. Quit as soon as we find one that works.
 # Don't assume this will work, provide a helpful diagnostic if it fails.
@@ -57,3 +94,5 @@ for opener in xdg-open open cygstart "start"; {
 }
 
 $open "$url" || (echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start" && exit 1);
+
+# vim: set ts=4 sw=4 noexpandtab:

--- a/bin/ghwd
+++ b/bin/ghwd
@@ -5,7 +5,7 @@ declare version="1.1.2"
 usage() {
 	printf '%s\n%s\n' \
 		'usage '"`basename "${1:-ghwd}"`"' -- open git URL in browser matching current branch and working directory' \
-		'ghwd [-svVh]' 
+		'ghwd [-rsvVh]' 
 	exit 64;
 }
 version() {
@@ -14,9 +14,15 @@ version() {
 }
 
 declare verbosity=1 #defaults to verbose
+declare f_return_only=0
 
-while getopts ":svVh" opt "$@"; do
+while getopts ":rsvVh" opt "$@"; do
 	case "$opt" in
+		(r)
+			#return mode returns the url, but does not open it
+			verbosity=1
+			f_return_only=1
+			;;
 		(s)
 			verbosity=0
 			;;
@@ -93,6 +99,8 @@ for opener in xdg-open open cygstart "start"; {
   fi
 }
 
-$open "$url" || (echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start" && exit 1);
+if [ $f_return_only -ne 1 ]; then
+	$open "$url" || { echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start"; exit 1; }
+fi
 
 # vim: set ts=4 sw=4 noexpandtab:


### PR DESCRIPTION
To make ghwd able to be incorporated inside other scripts I added a -r, -s, and -v option.  -r is return only mode, and only returns the URL that would have been opened and exits; this is for use in scripts that might want to do other operations than opening the URL.  The -s option is the silent option, which silences all output, and is the flag most scripts would want to use to best incorporate ghwd.  Each occurrence of a -v flag increments the verbosity variable so that there can be varying levels of verbosity in the future, e.g., "ghwd -vvv" could reveal debug information.  The variable defaults to 1, and therefore causes ghwd to function exactly as it does now, outputting the URL before opening it.

I also noticed some echo statements that were reporting errors were not redirected to stderr, so fixed that.  And changed the () to {} on ln. 93, because the parenthesis create a subshell, which is the shell exited with exit status 1 by the exit command—in other words, when ghwd can't find an appropriate opener and wants to tell the user that it didn't anticipate their operating system, it does so in a subshell and exits from that subshell with exit status 1, then exits from the actual ghwd shell with exit status 0, even though an error occured.

I'll be happy to write a manpage and update the README with usage information pertaining to these new options once I know what you think of them :)

note: this update will allow @stour to test his added functionality from #20, since now ghwd will be able to just return the URLs.

==test cases==
ghwd -v
>https://github.com/klmanion/ghwd/tree/feature/silent-and-verbose/bin
>*opens URL*

ghwd
[same as above]

ghwd -s
>*opens URL*

ghwd -r
>https://github.com/klmanion/ghwd/tree/feature/silent-and-verbose/bin
