### PR TITLE
Fixing wrong usage of last's command exit code and some cleaning...

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+readonly ERROR_NOT_A_GIT_REPO=78
+
 # Figure out github repo base URL
 base_url=$(git config --get remote.origin.url)
 base_url=${base_url%\.git} # remove .git from end of string
@@ -17,11 +19,10 @@ base_url=${base_url//git@bitbucket.org:/https:\/\/bitbucket\.org\/}
 base_url=${base_url//git@gitlab\.com:/https:\/\/gitlab\.com\/}
 
 # Validate that this folder is a git folder
-git branch 2>/dev/null 1>&2
-if [ $? -ne 0 ]; then
-  echo Not a git repo!
-  exit $?
-fi
+git branch > /dev/null 2>&1 || {
+    echo "Not a git repo!"
+    exit ${ERROR_NOT_A_GIT_REPO}
+}
 
 # Find current directory relative to .git parent
 full_path=$(pwd)
@@ -29,31 +30,35 @@ git_base_path=$(cd ./$(git rev-parse --show-cdup); pwd)
 relative_path=${full_path#$git_base_path} # remove leading git_base_path from working directory
 
 # If filename argument is present, append it
-if [ "$1" ]; then
-  relative_path="$relative_path/$1"
+if [[ ! -z "${1}" ]]; then
+    relative_path="${relative_path}/${1}"
 fi
 
 # Figure out current git branch
 # git_where=$(command git symbolic-ref -q HEAD || command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
-git_where=$(command git name-rev --name-only --no-undefined --always HEAD) 2>/dev/null
+git_where=$(command git name-rev --name-only --no-undefined --always HEAD) 2> /dev/null
 
 # Remove cruft from branchname
 branch="${git_where#refs\/heads\/}"
 branch="${branch#tags\/}"
 branch="${branch%^0}"
 
-[[ $base_url == *bitbucket* ]] && tree="src" || tree="tree"
-url="$base_url/$tree/$branch$relative_path"
+if [[ ${base_url} == *bitbucket* ]]; then
+    tree="src"
+else
+    tree="tree"
+fi
+url="${base_url}/${tree}/${branch}${relative_path}"
 
-echo "$url"
+echo "${url}"
 
 # Check for various OS openers. Quit as soon as we find one that works.
 # Don't assume this will work, provide a helpful diagnostic if it fails.
 for opener in xdg-open open cygstart "start"; {
-  if command -v $opener; then
-    open=$opener;
-    break;
-  fi
+    if command -v ${opener}; then
+        open=$opener;
+        break;
+    fi
 }
 
-$open "$url" || (echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start" && exit 1);
+${open} "${url}" || (echo "Unrecognized OS: Expected to find one of the following launch commands: xdg-open, open, cygstart, start" && exit 1);


### PR DESCRIPTION
There was an error here:

```
git branch 2>/dev/null 1>&2
if [ $? -ne 0 ]; then
  echo Not a git repo!
  exit $?
fi
```

$? is reading the status of the last command, which is echo, so it will alwats be 0 ... 

This is a good alternative:

```
git branch >/dev/null 2>&1
readonly RT_CODE=${?}
if ((RT_CODE != 0)); then
    echo "Not a git repo!"
    exit ${RT_CODE}
fi
```