### PR TITLE
Also remove remotes/origin/ from branch

### DIFF
--- a/bin/ghwd
+++ b/bin/ghwd
@@ -39,6 +39,7 @@ git_where=$(command git name-rev --name-only --no-undefined --always HEAD) 2>/de
 
 # Remove cruft from branchname
 branch="${git_where#refs\/heads\/}"
+branch="${git_where#remotes\/origin\/}"
 branch="${branch#tags\/}"
 branch="${branch%^0}"
 


### PR DESCRIPTION
I'm not sure what it is about my local setup that causes `git_where` to always contain `remotes/origin/`.

If anyone knows if this is something I can change locally, I would love that. But in case it's affecting other people too, here's a PR 😄 